### PR TITLE
Update Parse dep

### DIFF
--- a/iOSMinimalCocoaPodsSample/Podfile
+++ b/iOSMinimalCocoaPodsSample/Podfile
@@ -9,7 +9,7 @@ target 'iOSMinimalCocoaPodsSample' do
   pod 'AFNetworking', '~> 3.0'
   pod 'ORStackView', '~> 3.0'
   pod 'SwiftyJSON', '~> 4.0'
-  pod 'Parse', :git => 'https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git', :commit => '854dd75998636ac54edc16f8e4f1f3918788c598' 
+  pod 'Parse', :git => 'https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git', :commit => '931684b3dce25ec447d3df38b02e988970663c24'
 end
 
 target 'iOSMinimalCocoaPodsSampleTests' do

--- a/iOSMinimalCocoaPodsSample/Podfile.lock
+++ b/iOSMinimalCocoaPodsSample/Podfile.lock
@@ -14,24 +14,24 @@ PODS:
   - AFNetworking/Serialization (3.2.0)
   - AFNetworking/UIKit (3.2.0):
     - AFNetworking/NSURLSession
-  - Bolts/Tasks (1.9.0)
+  - Bolts/Tasks (1.9.1)
   - FLKAutoLayout (0.2.1)
   - ORStackView (3.0.1):
     - FLKAutoLayout (~> 0.2)
-  - Parse (1.16.0):
-    - Parse/Core (= 1.16.0)
-  - Parse/Core (1.16.0):
-    - Bolts/Tasks (~> 1.9)
+  - Parse (1.19.0):
+    - Parse/Core (= 1.19.0)
+  - Parse/Core (1.19.0):
+    - Bolts/Tasks (= 1.9.1)
   - SwiftyJSON (4.0.0)
 
 DEPENDENCIES:
   - AFNetworking (~> 3.0)
   - ORStackView (~> 3.0)
-  - Parse (from `https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git`, commit `854dd75998636ac54edc16f8e4f1f3918788c598`)
+  - Parse (from `https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git`, commit `931684b3dce25ec447d3df38b02e988970663c24`)
   - SwiftyJSON (~> 4.0)
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
+  https://github.com/CocoaPods/Specs.git:
     - AFNetworking
     - Bolts
     - FLKAutoLayout
@@ -40,22 +40,22 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   Parse:
-    :commit: 854dd75998636ac54edc16f8e4f1f3918788c598
+    :commit: 931684b3dce25ec447d3df38b02e988970663c24
     :git: https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git
 
 CHECKOUT OPTIONS:
   Parse:
-    :commit: 854dd75998636ac54edc16f8e4f1f3918788c598
+    :commit: 931684b3dce25ec447d3df38b02e988970663c24
     :git: https://github.com/ParsePlatform/Parse-SDK-iOS-OSX.git
 
 SPEC CHECKSUMS:
   AFNetworking: 8ac6017b94ea105479f7776e5288e48ae9c59bb4
-  Bolts: ac6567323eac61e203f6a9763667d0f711be34c8
+  Bolts: 8c1e8aab2f603387b8b9924f57d1d64f43d3ffdc
   FLKAutoLayout: 9db6b30c2008d230da608e62c607b11c23b942e6
   ORStackView: a1bb52748cd0ae29891c140baf22ff8972fb363c
-  Parse: 5b36dc2c2f0a2fd82a257ae018bc3d68cf2c24e7
+  Parse: 0fb5c7cc7ee5900f2434e24607d0496155b8d04f
   SwiftyJSON: 070dabdcb1beb81b247c65ffa3a79dbbfb3b48aa
 
-PODFILE CHECKSUM: 6d99e49afa3867058282c95c38c9df6a80ea8495
+PODFILE CHECKSUM: fba3b114cbfa4a81588063721c8e42c7c94d310b
 
 COCOAPODS: 1.5.3


### PR DESCRIPTION
https://app.bitrise.io/build/5139d45f1710c2d7#?tab=log

```
Last lines of the Xcode's build log:
    export LANG\=en_US.US-ASCII
    /Applications/Xcode-12.0.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -x objective-c -target armv7-apple-ios8.0 -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -std\=gnu11 -fobjc-arc -fobjc-weak -fmodules -gmodules -fmodules-cache-path\=/Users/vagrant/Library/Developer/Xcode/DerivedData/ModuleCache.noindex -fmodules-prune-interval\=86400 -fmodules-prune-after\=345600 -fbuild-session-file\=/Users/vagrant/Library/Developer/Xcode/DerivedData/ModuleCache.noindex/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror\=non-modular-include-in-framework-module -fmodule-name\=Parse -Wno-trigraphs -fpascal-strings -Os -fno-common -Wno-missing-field-initializers -Wno-missing-prototypes -Werror\=return-type -Wdocumentation -Wunreachable-code -Wno-implicit-atomic-properties -Werror\=deprecated-objc-isa-usage -Wno-objc-interface-ivars -Werror\=objc-root-class -Wno-arc-repeated-use-of-weak -Wimplicit-retain-self -Wduplicate-method-match -Wno-missing-braces -Wparentheses -Wswitch -Wunused-function -Wno-unused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconditional-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wno-float-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -Wno-selector -Wno-strict-selector-match -Wundeclared-selector -Wdeprecated-implementations -DPOD_CONFIGURATION_RELEASE\=1 -DCOCOAPODS\=1 -DNS_BLOCK_ASSERTIONS\=1 -DOBJC_OLD_DISPATCH_PROTOTYPES\=0 -isysroot /Applications/Xcode-12.0.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS14.0.sdk -fstrict-aliasing -Wprotocol -Wdeprecated-declarations -g -Wno-sign-conversion -Winfinite-recursion -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wno-semicolon-before-method-body -Wunguarded-availability -fembed-bitcode -iquote /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Parse-generated-files.hmap -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Parse-own-target-headers.hmap -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Parse-all-non-framework-target-headers.hmap -ivfsoverlay /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/all-product-headers.yaml -iquote /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Parse-project-headers.hmap -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/BuildProductsPath/Release-iphoneos/Parse/include -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/DerivedSources-normal/armv7 -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/DerivedSources/armv7 -I/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/DerivedSources -F/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/BuildProductsPath/Release-iphoneos/Parse -F/Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/BuildProductsPath/Release-iphoneos/Bolts -include /Users/vagrant/git/_tmp/iOSMinimalCocoaPodsSample/Pods/Target\ Support\ Files/Parse/Parse-prefix.pch -MMD -MT dependencies -MF /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Objects-normal/armv7/ParseClientConfiguration.d --serialize-diagnostics /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Objects-normal/armv7/ParseClientConfiguration.dia -c /Users/vagrant/git/_tmp/iOSMinimalCocoaPodsSample/Pods/Parse/Parse/Parse/ParseClientConfiguration.m -o /Users/vagrant/Library/Developer/Xcode/DerivedData/iOSMinimalCocoaPodsSample-gacbnrlhoyldpmgesxjifxqzjrvh/Build/Intermediates.noindex/ArchiveIntermediates/iOSMinimalCocoaPodsSample/IntermediateBuildFilesPath/Pods.build/Release-iphoneos/Parse.build/Objects-normal/armv7/ParseClientConfiguration.o
/Users/vagrant/git/_tmp/iOSMinimalCocoaPodsSample/Pods/Parse/Parse/Parse/ParseClientConfiguration.m:127:61: error: incompatible block pointer types sending 'void (^)(ParseClientConfiguration *__strong)' to parameter of type 'void (^ _Nonnull)(id<ParseMutableClientConfiguration>  _Nonnull __strong)'
    return [ParseClientConfiguration configurationWithBlock:^(ParseClientConfiguration *configuration) {
                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /Users/vagrant/git/_tmp/iOSMinimalCocoaPodsSample/Pods/Parse/Parse/Parse/ParseClientConfiguration.m:10:
/Users/vagrant/git/_tmp/iOSMinimalCocoaPodsSample/Pods/Parse/Parse/Parse/ParseClientConfiguration.h:196:101: note: passing argument to parameter 'configurationBlock' here
+ (instancetype)configurationWithBlock:(void (^)(id<ParseMutableClientConfiguration> configuration))configurationBlock;
                                                                                                    ^
1 error generated.
```